### PR TITLE
Allow empty strings as property values

### DIFF
--- a/pyfdt/pyfdt.py
+++ b/pyfdt/pyfdt.py
@@ -167,8 +167,6 @@ class FdtPropertyStrings(FdtProperty):
         if not strings:
             raise Exception("Invalid strings")
         for stri in strings:
-            if len(stri) == 0:
-                raise Exception("Invalid strings")
             if any([True for char in stri
                         if char not in string.printable 
                            or char in ('\r', '\n')]):


### PR DESCRIPTION
Hi,

The Devicetree specification (release 0.1) states in section 2.2.4 that:
> A property value is an array of zero or more bytes that contain information associated with the property

Empty strings are therefore valid. They are also used in some devicetrees of the Linux kernel and other projects that also use device trees. Also, `dtc` is fine with empty strings.

Best regards,
Jean